### PR TITLE
Update to the Paper API.

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ with `-java<version>-slim-bullseye`.
 **Examples:**
 
 - `velocity-java17-slim-bullseye`
-- `velocity-3.0.1-java17-slim-bullseye`
+- `velocity-3.0.1-95-java17-slim-bullseye`
 
 ### Eclipse Temurin Alpine (`temurin*-alpine`)
 
@@ -57,4 +57,4 @@ This image is based on Eclipse Temurin's Alpine image. The image format is suffi
 **Examples:**
 
 - `velocity-temurin17-alpine`
-- `velocity-3.0.1-temurin17-alpine`
+- `velocity-3.0.1-95-temurin17-alpine`

--- a/velocity/alpine/Dockerfile
+++ b/velocity/alpine/Dockerfile
@@ -16,7 +16,7 @@ RUN addgroup -g 1000 minecraft \
   && adduser -Ss /bin/false -u 1000 -G minecraft -h /home/minecraft minecraft \
   && mkdir -m 775 /data \
   && chown minecraft:minecraft /data \
-  && wget -O /server.jar "https://papermc.io/api/v2/projects/velocity/versions/$VELOCITY_VERSION/builds/$VELOCITY_BUILD/downloads/velocity-$VELOCITY_VERSION-$VELOCITY_BUILD.jar"
+  && wget -O /server.jar "https://papermc.io/api/v2/projects/velocity/versions/$VELOCITY_VERSION/builds/$VELOCITY_BUILD/downloads/velocity-$VELOCITY_VERSION-$VELOCITY_BUILD.jar" \
   && echo "$VELOCITY_SHA256  /server.jar" | sha256sum -c -
 
 COPY bin/start.sh /start.sh

--- a/velocity/alpine/Dockerfile
+++ b/velocity/alpine/Dockerfile
@@ -9,12 +9,15 @@ LABEL org.opencontainers.image.source="https://github.com/Cubxity/docker-minecra
 LABEL org.opencontainers.image.version="velocity-$VELOCITY_VERSION-$RUNTIME_NAME"
 
 ARG VELOCITY_VERSION
+ARG VELOCITY_BUILD
+ARG VELOCITY_SHA256
 
 RUN addgroup -g 1000 minecraft \
   && adduser -Ss /bin/false -u 1000 -G minecraft -h /home/minecraft minecraft \
   && mkdir -m 775 /data \
   && chown minecraft:minecraft /data \
-  && wget -O /server.jar "https://versions.velocitypowered.com/download/$VELOCITY_VERSION.jar"
+  && wget -O /server.jar "https://papermc.io/api/v2/projects/velocity/versions/$VELOCITY_VERSION/builds/$VELOCITY_BUILD/downloads/velocity-$VELOCITY_VERSION-$VELOCITY_BUILD.jar"
+  && echo "$VELOCITY_SHA256  /server.jar" | sha256sum -c -
 
 COPY bin/start.sh /start.sh
 

--- a/velocity/build.sh
+++ b/velocity/build.sh
@@ -1,12 +1,20 @@
 #!/bin/bash
+
 version=$(curl -s "https://nexus.velocitypowered.com/repository/maven-public/com/velocitypowered/velocity-native/maven-metadata.xml" | sed -n 's/.*<release>\([^<]*\)<\/release>/\1/p')
 
-echo "[velocity] building velocity-$version-$RUNTIME_NAME"
+curl -s https://papermc.io/api/v2/projects/velocity/ | jq -r -c ".versions[]" | while read -r version; do
+  build=$(curl -s "https://papermc.io/api/v2/projects/velocity/versions/$version" | jq -r ".builds[-1]")
+  hash=$(curl -s "https://papermc.io/api/v2/projects/velocity/versions/$version/builds/$version" | jq -r ".downloads.application.sha256")
+
+
+echo "[velocity] building velocity-$version-$build-$RUNTIME_NAME"
 
 docker buildx build \
   --build-arg "RUNTIME=$RUNTIME_IMAGE" \
   --build-arg "RUNTIME_NAME=$RUNTIME_NAME" \
   --build-arg "VELOCITY_VERSION=$version" \
+  --build-arg "VELOCITY_BUILD=$build"
+  --build-arg "VELOCITY_SHA256=$hash"
   --tag "$REPOSITORY:velocity-$version-$RUNTIME_NAME" \
   --tag "$REPOSITORY:velocity-$RUNTIME_NAME" \
   --cache-from "type=registry,ref=$REPOSITORY:velocity-$version-$RUNTIME_NAME" \

--- a/velocity/build.sh
+++ b/velocity/build.sh
@@ -1,11 +1,9 @@
 #!/bin/bash
-
 version=$(curl -s "https://nexus.velocitypowered.com/repository/maven-public/com/velocitypowered/velocity-native/maven-metadata.xml" | sed -n 's/.*<release>\([^<]*\)<\/release>/\1/p')
 
 curl -s https://papermc.io/api/v2/projects/velocity/ | jq -r -c ".versions[]" | while read -r version; do
   build=$(curl -s "https://papermc.io/api/v2/projects/velocity/versions/$version" | jq -r ".builds[-1]")
   hash=$(curl -s "https://papermc.io/api/v2/projects/velocity/versions/$version/builds/$version" | jq -r ".downloads.application.sha256")
-
 
 echo "[velocity] building velocity-$version-$build-$RUNTIME_NAME"
 
@@ -13,8 +11,8 @@ docker buildx build \
   --build-arg "RUNTIME=$RUNTIME_IMAGE" \
   --build-arg "RUNTIME_NAME=$RUNTIME_NAME" \
   --build-arg "VELOCITY_VERSION=$version" \
-  --build-arg "VELOCITY_BUILD=$build"
-  --build-arg "VELOCITY_SHA256=$hash"
+  --build-arg "VELOCITY_BUILD=$build" \
+  --build-arg "VELOCITY_SHA256=$hash" \
   --tag "$REPOSITORY:velocity-$version-$RUNTIME_NAME" \
   --tag "$REPOSITORY:velocity-$RUNTIME_NAME" \
   --cache-from "type=registry,ref=$REPOSITORY:velocity-$version-$RUNTIME_NAME" \
@@ -23,3 +21,4 @@ docker buildx build \
   --platform "$RUNTIME_PLATFORM" \
   --push \
   . || exit 1
+done

--- a/velocity/build.sh
+++ b/velocity/build.sh
@@ -3,7 +3,7 @@ version=$(curl -s "https://nexus.velocitypowered.com/repository/maven-public/com
 
 curl -s https://papermc.io/api/v2/projects/velocity/ | jq -r -c ".versions[]" | while read -r version; do
   build=$(curl -s "https://papermc.io/api/v2/projects/velocity/versions/$version" | jq -r ".builds[-1]")
-  hash=$(curl -s "https://papermc.io/api/v2/projects/velocity/versions/$version/builds/$version" | jq -r ".downloads.application.sha256")
+  hash=$(curl -s "https://papermc.io/api/v2/projects/velocity/versions/$version/builds/$build" | jq -r ".downloads.application.sha256")
 
 echo "[velocity] building velocity-$version-$build-$RUNTIME_NAME"
 

--- a/velocity/debian/Dockerfile
+++ b/velocity/debian/Dockerfile
@@ -17,7 +17,7 @@ RUN groupadd -g 1000 minecraft \
   && mkdir -m 775 /data \
   && chown minecraft:minecraft /data \
   && apt-get update && apt-get install -y curl \
-  && curl -sfL -o /server.jar "https://papermc.io/api/v2/projects/velocity/versions/$VELOCITY_VERSION/builds/$VELOCITY_BUILD/downloads/velocity-$VELOCITY_VERSION-$VELOCITY_BUILD.jar"
+  && curl -sfL -o /server.jar "https://papermc.io/api/v2/projects/velocity/versions/$VELOCITY_VERSION/builds/$VELOCITY_BUILD/downloads/velocity-$VELOCITY_VERSION-$VELOCITY_BUILD.jar" \
   && echo "$VELOCITY_SHA256  /server.jar" | sha256sum -c -
 
 COPY bin/start.sh /start.sh

--- a/velocity/debian/Dockerfile
+++ b/velocity/debian/Dockerfile
@@ -9,13 +9,16 @@ LABEL org.opencontainers.image.source="https://github.com/Cubxity/docker-minecra
 LABEL org.opencontainers.image.version="velocity-$VELOCITY_VERSION-$RUNTIME_NAME"
 
 ARG VELOCITY_VERSION
+ARG VELOCITY_BUILD
+ARG VELOCITY_SHA256
 
 RUN groupadd -g 1000 minecraft \
   && useradd -r -s /bin/false -u 1000 -g 1000 -m minecraft \
   && mkdir -m 775 /data \
   && chown minecraft:minecraft /data \
   && apt-get update && apt-get install -y curl \
-  && curl -sfL -o /server.jar "https://versions.velocitypowered.com/download/$VELOCITY_VERSION.jar"
+  && curl -sfL -o /server.jar "https://papermc.io/api/v2/projects/velocity/versions/$VELOCITY_VERSION/builds/$VELOCITY_BUILD/downloads/velocity-$VELOCITY_VERSION-$VELOCITY_BUILD.jar"
+  && echo "$VELOCITY_SHA256  /server.jar" | sha256sum -c -
 
 COPY bin/start.sh /start.sh
 


### PR DESCRIPTION
Updated the links to the Paper Velocity API, and also added 2 new args:
- `VELOCITY_BUILD`, which will be used as the build number.
- `VELOCITY_SHA256` which is the SHA256, as the Paper API provides this.

Please let me know if I should change anything!