### PR TITLE
Swap from OpenJDK to Azul Zulu

### DIFF
--- a/.github/workflows/velocity.yml
+++ b/.github/workflows/velocity.yml
@@ -17,12 +17,12 @@ jobs:
     strategy:
       matrix:
         runtime:
-          - image: openjdk:17-slim-bullseye
+          - image: azul/zulu-openjdk-debian:17-latest
             name: java17-slim-bullseye
             version: 17
             platform: linux/amd64,linux/arm64/v8
             os: debian
-          - image: openjdk:11-slim-bullseye
+          - image: azul/zulu-openjdk-debian:11-latest
             name: java11-slim-bullseye
             version: 11
             platform: linux/amd64,linux/arm64/v8

--- a/README.md
+++ b/README.md
@@ -31,16 +31,15 @@ This image makes use of Velocity's recommended flags by default. The data direct
 
 ## Variants
 
-This repository provides OpenJDK and Eclipse Temurin based container images for **Velocity**.
+This repository provides Azul Zulu and Eclipse Temurin based container images for **Velocity**.
 
-> **NOTE:** AdoptOpenJDK (`adopt*`) variants are **deprecated** in favor of OpenJDK and Temurin.
-> Support for non-LTS versions may be dropped at any time.
+> **NOTE:** OpenJDK images are fully **deprecated** in favor of Azul Zulu and Temurin.
 
-### OpenJDK (`java*-slim-bullseye`)
+### Azul Zulu (`java*-slim-bullseye`)
 
 Supports `linux/amd64` and `linux/arm64`.
 
-This image is based on OpenJDK's Debian slim Bullseye image. The image format is suffixed
+This image is based on Azul Zulu's Debian slim Bullseye image. The image format is suffixed
 with `-java<version>-slim-bullseye`.
 
 **Examples:**

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ This repository provides Azul Zulu and Eclipse Temurin based container images fo
 
 > **NOTE:** OpenJDK images are fully **deprecated** in favor of Azul Zulu and Temurin.
 
-### Azul Zulu (`java*-slim-bullseye`)
+### Azul Zulu Debian (`java*-slim-bullseye`)
 
 Supports `linux/amd64` and `linux/arm64`.
 


### PR DESCRIPTION
I've kept the user facing name, just swapped the base.

Optionally, Azul provides Alpine images as well making it possible to not use Temurin at all - but I wanted a thumbs up on this before making that move.

Azul Zulu is best known for it's first in class support on M1 (M2) devices.

Closes #4